### PR TITLE
Mark vestigal hediffs as non-bad

### DIFF
--- a/1.4/Defs/HediffDefs/Hediff_VestigialEyes.xml
+++ b/1.4/Defs/HediffDefs/Hediff_VestigialEyes.xml
@@ -11,6 +11,7 @@
 		<defaultLabelColor>(0.5, 0.5, 0.5)</defaultLabelColor>
 		<tendable>false</tendable>
 		<displayWound>false</displayWound>
+		<isBad>false</isBad>
 	</HediffDef>
 
 	<HediffDef ParentName="InjuryBase">
@@ -18,6 +19,7 @@
 		<label>vestigial</label>
 		<labelNoun>a vestigial part</labelNoun>
 		<description>A vestigial part.</description>
+		<isBad>false</isBad>
 		<injuryProps>
 			<canMerge>false</canMerge>
 			<destroyedLabel>vestigial</destroyedLabel>

--- a/1.5/Defs/HediffDefs/Hediff_VestigialEyes.xml
+++ b/1.5/Defs/HediffDefs/Hediff_VestigialEyes.xml
@@ -11,6 +11,7 @@
 		<defaultLabelColor>(0.5, 0.5, 0.5)</defaultLabelColor>
 		<tendable>false</tendable>
 		<displayWound>false</displayWound>
+		<isBad>false</isBad>
 	</HediffDef>
 
 	<HediffDef ParentName="InjuryBase">
@@ -18,6 +19,7 @@
 		<label>vestigial</label>
 		<labelNoun>a vestigial part</labelNoun>
 		<description>A vestigial part.</description>
+		<isBad>false</isBad>
 		<injuryProps>
 			<canMerge>false</canMerge>
 			<destroyedLabel>vestigial</destroyedLabel>


### PR DESCRIPTION
Adds the vanilla `<isBad>false<isBad>` tag to the vestigal body part hediffs, so that the advanced medical beds from the [MedPod](https://steamcommunity.com/sharedfiles/filedetails/?id=2153065191) mod does not unintentionally remove them during treatment.

(By default, MedPods will treat any hediffs missing the `<isBad>false<isBad>`, or is otherwise not formally blacklisted)